### PR TITLE
define width of popup image

### DIFF
--- a/module-06/lab-06/lab-06-data/index.html
+++ b/module-06/lab-06/lab-06-data/index.html
@@ -57,7 +57,9 @@
         .CA-blue {
             color: #345989;
         }
-        
+        .leaflet-popup-content img {
+            width: 100%;
+        }
         
     </style>
 </head>


### PR DESCRIPTION
- explicitly set image within leaflet popup to 100% wide
